### PR TITLE
Fix rst formatting for example code in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,42 +7,46 @@ Automation Library for Yamaha receivers that support the YNCA protocol.
 Installation
 ============
 
-pip3 install ynca
+.. code-block:: bash
+
+    pip3 install ynca
 
 
 Usage
 =====
 
 This package contains:
- * YncaReceiver: a class that represents YNCA capable receiver and allows you to control it
- * ynca_console: a function that provides a console to directly give YNCA commands and see the responses (debugging)
+
+``YncaReceiver``
+    a class that represents YNCA capable receiver and allows you to control it
+``ynca_console``
+    a function that provides a console to directly give YNCA commands and see the responses (debugging)
 
 Example
 =======
-# Create a receiver object. This call takes a while (multiple seconds) since
-# it communicates quite a lot with the actual device.
-# Note that later calls that control the receiver are are fast (they get async responses)
-receiver = ynca.YncaReceiver("/dev/tty1")  # Port could also be e.g. COM3 on Windows or 192.168.1.12 for IP connection
 
-# Attributes that are still None after initialization are not supported by the receiver/zone
-#``receiver.zones`` is a dictionary with all available zone object for the receiver
-main = receiver.zones["MAIN"]  # other possible zones are ZONE2, ZONE3 and ZONE4
-print(main.name)  # Print the name of the main zone
+.. code-block:: python
 
-#``receiver.inputs`` is a dictionary of available inputs with the key being the unique ID and the value the friendly name
-if available
-print(main.inputs)
+    # Create a receiver object. This call takes a while (multiple seconds) since
+    # it communicates quite a lot with the actual device.
+    # Note that later calls that control the receiver are are fast (they get async responses)
+    receiver = ynca.YncaReceiver("/dev/tty1")  # Port could also be e.g. COM3 on Windows or 192.168.1.12 for IP connection
 
-# To get notifications when something changes register callbacks
-def on_update_callback():
-    pass
-main.on_update_callback = on_update_callback
+    # Attributes that are still None after initialization are not supported by the receiver/zone
+    # ``receiver.zones`` is a dictionary with all available zone object for the receiver
+    main = receiver.zones["MAIN"]  # other possible zones are ZONE2, ZONE3 and ZONE4
+    print(main.name)  # Print the name of the main zone
 
-# Examples to control the zone
-main.on = True
-main.input = "HDMI3"
-main.volume_up()
+    # ``receiver.inputs`` is a dictionary of available inputs with the key being
+    # the unique ID and the value the friendly name if available
+    print(main.inputs)
 
+    # To get notifications when something changes register callbacks
+    def on_update_callback():
+        pass
+    main.on_update_callback = on_update_callback
 
-
-
+    # Examples to control the zone
+    main.on = True
+    main.input = "HDMI3"
+    main.volume_up()


### PR DESCRIPTION
1. Fix formatting for Example section:
    * indent the example code block for rendering.
    * tag the indented code block as python for syntax highlighting
2. Fix formatting for Install section.
3. Dictionary list for Usage section.
