### PR TITLE
More robust ynca handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ sys = ynca_receiver.SYS
 main = ynca_receiver.MAIN
 
 print(sys.modelname) # Print the modelname of the system
-print(main.name) # Print the name of the main zone
+print(main.zonename) # Print the name of the main zone
 
 # The `get_all_zone_inputs` helper returns a dictionary of available inputs
 # with the key being the ID to be used for setting the input on a Zone subunit

--- a/example.py
+++ b/example.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     for subunit_id in ZONE_SUBUNIT_IDS:
         if zone := getattr(ynca_receiver, subunit_id, None):
             print("  --- {} ---".format(zone.id))
-            print(f"  {zone.name=}")
+            print(f"  {zone.zonename=}")
             print(f"  {zone.volume=}")
             print(f"  {zone.input=}")
 

--- a/logs/README.md
+++ b/logs/README.md
@@ -1,0 +1,4 @@
+# Logs
+
+This directory contains logs for several receivers for reference.
+These files can be used with the `ynca_server.py` scripts `--initfile` option for testing

--- a/logs/RX-A810.txt
+++ b/logs/RX-A810.txt
@@ -1,0 +1,248 @@
+2022-07-16 20:35:21 DEBUG (Thread-3) [ynca.connection] Connected
+2022-07-16 20:35:21 DEBUG (Thread-4) [ynca.connection] < @SYS:MODELNAME=?
+2022-07-16 20:35:21 DEBUG (SyncWorker_0) [ynca.ynca] Subunit availability check start
+2022-07-16 20:35:21 DEBUG (Thread-3) [ynca.connection] > @SYS:MODELNAME=RX-A810
+2022-07-16 20:35:22 DEBUG (Thread-4) [ynca.connection] < @SYS:MODELNAME=?
+2022-07-16 20:35:22 DEBUG (Thread-3) [ynca.connection] > @SYS:MODELNAME=RX-A810
+2022-07-16 20:35:22 DEBUG (Thread-4) [ynca.connection] < @SYS:AVAIL=?
+2022-07-16 20:35:22 DEBUG (Thread-3) [ynca.connection] > @UNDEFINED
+2022-07-16 20:35:22 DEBUG (Thread-4) [ynca.connection] < @MAIN:AVAIL=?
+2022-07-16 20:35:22 DEBUG (Thread-3) [ynca.connection] > @MAIN:AVAIL=Not Ready
+2022-07-16 20:35:22 DEBUG (Thread-4) [ynca.connection] < @ZONE2:AVAIL=?
+2022-07-16 20:35:22 DEBUG (Thread-3) [ynca.connection] > @ZONE2:AVAIL=Not Ready
+2022-07-16 20:35:22 DEBUG (Thread-4) [ynca.connection] < @ZONE3:AVAIL=?
+2022-07-16 20:35:22 DEBUG (Thread-3) [ynca.connection] > @RESTRICTED
+2022-07-16 20:35:22 DEBUG (Thread-4) [ynca.connection] < @ZONE4:AVAIL=?
+2022-07-16 20:35:22 DEBUG (Thread-3) [ynca.connection] > @RESTRICTED
+2022-07-16 20:35:22 DEBUG (Thread-4) [ynca.connection] < @TUN:AVAIL=?
+2022-07-16 20:35:22 DEBUG (Thread-3) [ynca.connection] > @TUN:AVAIL=Not Ready
+2022-07-16 20:35:22 DEBUG (Thread-4) [ynca.connection] < @SIRIUS:AVAIL=?
+2022-07-16 20:35:22 DEBUG (Thread-3) [ynca.connection] > @RESTRICTED
+2022-07-16 20:35:22 DEBUG (Thread-4) [ynca.connection] < @IPOD:AVAIL=?
+2022-07-16 20:35:22 DEBUG (Thread-3) [ynca.connection] > @IPOD:AVAIL=Not Connected
+2022-07-16 20:35:22 DEBUG (Thread-4) [ynca.connection] < @BT:AVAIL=?
+2022-07-16 20:35:22 DEBUG (Thread-3) [ynca.connection] > @BT:AVAIL=Not Connected
+2022-07-16 20:35:23 DEBUG (Thread-4) [ynca.connection] < @RHAP:AVAIL=?
+2022-07-16 20:35:23 DEBUG (Thread-3) [ynca.connection] > @RESTRICTED
+2022-07-16 20:35:23 DEBUG (Thread-4) [ynca.connection] < @SIRIUSIR:AVAIL=?
+2022-07-16 20:35:23 DEBUG (Thread-3) [ynca.connection] > @RESTRICTED
+2022-07-16 20:35:23 DEBUG (Thread-4) [ynca.connection] < @PANDORA:AVAIL=?
+2022-07-16 20:35:23 DEBUG (Thread-3) [ynca.connection] > @RESTRICTED
+2022-07-16 20:35:23 DEBUG (Thread-4) [ynca.connection] < @NAPSTER:AVAIL=?
+2022-07-16 20:35:23 DEBUG (Thread-3) [ynca.connection] > @NAPSTER:AVAIL=Not Ready
+2022-07-16 20:35:23 DEBUG (Thread-4) [ynca.connection] < @PC:AVAIL=?
+2022-07-16 20:35:23 DEBUG (Thread-3) [ynca.connection] > @PC:AVAIL=Not Ready
+2022-07-16 20:35:23 DEBUG (Thread-4) [ynca.connection] < @NETRADIO:AVAIL=?
+2022-07-16 20:35:23 DEBUG (Thread-3) [ynca.connection] > @NETRADIO:AVAIL=Not Ready
+2022-07-16 20:35:23 DEBUG (Thread-4) [ynca.connection] < @USB:AVAIL=?
+2022-07-16 20:35:23 DEBUG (Thread-3) [ynca.connection] > @USB:AVAIL=Not Connected
+2022-07-16 20:35:23 DEBUG (Thread-4) [ynca.connection] < @IPODUSB:AVAIL=?
+2022-07-16 20:35:23 DEBUG (Thread-3) [ynca.connection] > @IPODUSB:AVAIL=Not Connected
+2022-07-16 20:35:23 DEBUG (Thread-4) [ynca.connection] < @UAW:AVAIL=?
+2022-07-16 20:35:23 DEBUG (Thread-3) [ynca.connection] > @UAW:AVAIL=Not Connected
+2022-07-16 20:35:23 DEBUG (Thread-4) [ynca.connection] < @SIRIUSXM:AVAIL=?
+2022-07-16 20:35:23 DEBUG (Thread-3) [ynca.connection] > @UNDEFINED
+2022-07-16 20:35:24 DEBUG (Thread-4) [ynca.connection] < @SPOTIFY:AVAIL=?
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @UNDEFINED
+2022-07-16 20:35:24 DEBUG (Thread-4) [ynca.connection] < @SERVER:AVAIL=?
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @UNDEFINED
+2022-07-16 20:35:24 DEBUG (Thread-4) [ynca.connection] < @AIRPLAY:AVAIL=?
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @UNDEFINED
+2022-07-16 20:35:24 DEBUG (Thread-4) [ynca.connection] < @SYS:VERSION=?
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:VERSION=1.80/2.01
+2022-07-16 20:35:24 DEBUG (SyncWorker_0) [ynca.ynca] Subunit availability check done
+2022-07-16 20:35:24 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.SYS initialization start.
+2022-07-16 20:35:24 DEBUG (Thread-4) [ynca.connection] < @SYS:AVAIL=?
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @UNDEFINED
+2022-07-16 20:35:24 DEBUG (Thread-4) [ynca.connection] < @SYS:PWR=?
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:PWR=Standby
+2022-07-16 20:35:24 DEBUG (Thread-4) [ynca.connection] < @SYS:MODELNAME=?
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:MODELNAME=RX-A810
+2022-07-16 20:35:24 DEBUG (Thread-4) [ynca.connection] < @SYS:INPNAME=?
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:INPNAMEPHONO=PHONO
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:INPNAMEHDMI1=Blu-ray
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:INPNAMEHDMI2=Shield
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:INPNAMEHDMI3=HTPC
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:INPNAMEHDMI4=HassIO
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:INPNAMEHDMI5=Cromecast
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:INPNAMEHDMI6=SteamLink
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:INPNAMEHDMI7=HDMI7
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:INPNAMEAV1=AV1
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:INPNAMEAV2=AV2
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:INPNAMEAV3=AV3
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:INPNAMEAV4=AV4
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:INPNAMEAV5=XBox
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:INPNAMEAV6=AV6
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:INPNAMEVAUX=V-AUX
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:INPNAMEAUDIO1=AUDIO1
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:INPNAMEAUDIO2=AUDIO2
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:INPNAMEDOCK=DOCK
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:INPNAMEUSB=USB
+2022-07-16 20:35:24 DEBUG (Thread-4) [ynca.connection] < @SYS:VERSION=?
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @SYS:VERSION=1.80/2.01
+2022-07-16 20:35:24 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.SYS initialization done.
+2022-07-16 20:35:24 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.BT initialization start.
+2022-07-16 20:35:24 DEBUG (Thread-4) [ynca.connection] < @BT:AVAIL=?
+2022-07-16 20:35:24 DEBUG (Thread-3) [ynca.connection] > @BT:AVAIL=Not Connected
+2022-07-16 20:35:25 DEBUG (Thread-4) [ynca.connection] < @SYS:VERSION=?
+2022-07-16 20:35:25 DEBUG (Thread-3) [ynca.connection] > @SYS:VERSION=1.80/2.01
+2022-07-16 20:35:25 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.BT initialization done.
+2022-07-16 20:35:25 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.IPOD initialization start.
+2022-07-16 20:35:25 DEBUG (Thread-4) [ynca.connection] < @IPOD:AVAIL=?
+2022-07-16 20:35:25 DEBUG (Thread-3) [ynca.connection] > @IPOD:AVAIL=Not Connected
+2022-07-16 20:35:25 DEBUG (Thread-4) [ynca.connection] < @IPOD:PLAYBACKINFO=?
+2022-07-16 20:35:25 DEBUG (Thread-3) [ynca.connection] > @IPOD:PLAYBACKINFO=Stop
+2022-07-16 20:35:25 DEBUG (Thread-4) [ynca.connection] < @IPOD:METAINFO=?
+2022-07-16 20:35:25 DEBUG (Thread-3) [ynca.connection] > @IPOD:ARTIST=
+2022-07-16 20:35:25 DEBUG (Thread-3) [ynca.connection] > @IPOD:ALBUM=
+2022-07-16 20:35:25 DEBUG (Thread-3) [ynca.connection] > @IPOD:SONG=
+2022-07-16 20:35:25 DEBUG (Thread-4) [ynca.connection] < @IPOD:REPEAT=?
+2022-07-16 20:35:25 DEBUG (Thread-3) [ynca.connection] > @IPOD:REPEAT=Off
+2022-07-16 20:35:25 DEBUG (Thread-4) [ynca.connection] < @IPOD:SHUFFLE=?
+2022-07-16 20:35:25 DEBUG (Thread-3) [ynca.connection] > @IPOD:SHUFFLE=Off
+2022-07-16 20:35:25 DEBUG (Thread-4) [ynca.connection] < @SYS:VERSION=?
+2022-07-16 20:35:25 DEBUG (Thread-3) [ynca.connection] > @SYS:VERSION=1.80/2.01
+2022-07-16 20:35:25 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.IPOD initialization done.
+2022-07-16 20:35:25 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.IPODUSB initialization start.
+2022-07-16 20:35:25 DEBUG (Thread-4) [ynca.connection] < @IPODUSB:AVAIL=?
+2022-07-16 20:35:25 DEBUG (Thread-3) [ynca.connection] > @IPODUSB:AVAIL=Not Connected
+2022-07-16 20:35:25 DEBUG (Thread-4) [ynca.connection] < @IPODUSB:PLAYBACKINFO=?
+2022-07-16 20:35:25 DEBUG (Thread-3) [ynca.connection] > @IPODUSB:PLAYBACKINFO=Stop
+2022-07-16 20:35:25 DEBUG (Thread-4) [ynca.connection] < @IPODUSB:METAINFO=?
+2022-07-16 20:35:25 DEBUG (Thread-3) [ynca.connection] > @IPODUSB:ARTIST=
+2022-07-16 20:35:25 DEBUG (Thread-3) [ynca.connection] > @IPODUSB:ALBUM=
+2022-07-16 20:35:25 DEBUG (Thread-3) [ynca.connection] > @IPODUSB:SONG=
+2022-07-16 20:35:26 DEBUG (Thread-4) [ynca.connection] < @IPODUSB:REPEAT=?
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @IPODUSB:REPEAT=Off
+2022-07-16 20:35:26 DEBUG (Thread-4) [ynca.connection] < @IPODUSB:SHUFFLE=?
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @IPODUSB:SHUFFLE=Off
+2022-07-16 20:35:26 DEBUG (Thread-4) [ynca.connection] < @SYS:VERSION=?
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @SYS:VERSION=1.80/2.01
+2022-07-16 20:35:26 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.IPODUSB initialization done.
+2022-07-16 20:35:26 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.MAIN initialization start.
+2022-07-16 20:35:26 DEBUG (Thread-4) [ynca.connection] < @MAIN:AVAIL=?
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:AVAIL=Not Ready
+2022-07-16 20:35:26 DEBUG (Thread-4) [ynca.connection] < @MAIN:PWR=?
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:PWR=Standby
+2022-07-16 20:35:26 DEBUG (Thread-4) [ynca.connection] < @MAIN:BASIC=?
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:PWR=Standby
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:SLEEP=Off
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:VOL=-34.0
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:MUTE=Off
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:INP=HDMI2
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:STRAIGHT=Off
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:ENHANCER=On
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:SOUNDPRG=Standard
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:3DCINEMA=Auto
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:PUREDIRMODE=Off
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:SPBASS=0.0
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:SPTREBLE=0.0
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:ADAPTIVEDRC=Off
+2022-07-16 20:35:26 DEBUG (Thread-4) [ynca.connection] < @MAIN:MAXVOL=?
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:MAXVOL=0.0
+2022-07-16 20:35:26 DEBUG (Thread-4) [ynca.connection] < @MAIN:SCENENAME=?
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:SCENE1NAME=BD/DVD Movie Viewing
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:SCENE2NAME=TV Viewing
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:SCENE3NAME=Mediacenter
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:SCENE4NAME=Radio Listening
+2022-07-16 20:35:26 DEBUG (Thread-4) [ynca.connection] < @MAIN:ZONENAME=?
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @MAIN:ZONENAME=Main
+2022-07-16 20:35:26 DEBUG (Thread-4) [ynca.connection] < @SYS:VERSION=?
+2022-07-16 20:35:26 DEBUG (Thread-3) [ynca.connection] > @SYS:VERSION=1.80/2.01
+2022-07-16 20:35:26 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.MAIN initialization done.
+2022-07-16 20:35:26 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.NAPSTER initialization start.
+2022-07-16 20:35:27 DEBUG (Thread-4) [ynca.connection] < @NAPSTER:AVAIL=?
+2022-07-16 20:35:27 DEBUG (Thread-3) [ynca.connection] > @NAPSTER:AVAIL=Not Ready
+2022-07-16 20:35:27 DEBUG (Thread-4) [ynca.connection] < @NAPSTER:PLAYBACKINFO=?
+2022-07-16 20:35:27 DEBUG (Thread-3) [ynca.connection] > @NAPSTER:PLAYBACKINFO=Stop
+2022-07-16 20:35:27 DEBUG (Thread-4) [ynca.connection] < @NAPSTER:METAINFO=?
+2022-07-16 20:35:27 DEBUG (Thread-3) [ynca.connection] > @NAPSTER:ARTIST=
+2022-07-16 20:35:27 DEBUG (Thread-3) [ynca.connection] > @NAPSTER:ALBUM=
+2022-07-16 20:35:27 DEBUG (Thread-3) [ynca.connection] > @NAPSTER:SONG=
+2022-07-16 20:35:27 DEBUG (Thread-4) [ynca.connection] < @NAPSTER:REPEAT=?
+2022-07-16 20:35:27 DEBUG (Thread-3) [ynca.connection] > @NAPSTER:REPEAT=Off
+2022-07-16 20:35:27 DEBUG (Thread-4) [ynca.connection] < @NAPSTER:SHUFFLE=?
+2022-07-16 20:35:27 DEBUG (Thread-3) [ynca.connection] > @NAPSTER:SHUFFLE=On
+2022-07-16 20:35:27 DEBUG (Thread-4) [ynca.connection] < @SYS:VERSION=?
+2022-07-16 20:35:27 DEBUG (Thread-3) [ynca.connection] > @SYS:VERSION=1.80/2.01
+2022-07-16 20:35:27 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.NAPSTER initialization done.
+2022-07-16 20:35:27 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.NETRADIO initialization start.
+2022-07-16 20:35:27 DEBUG (Thread-4) [ynca.connection] < @NETRADIO:AVAIL=?
+2022-07-16 20:35:27 DEBUG (Thread-3) [ynca.connection] > @NETRADIO:AVAIL=Not Ready
+2022-07-16 20:35:27 DEBUG (Thread-4) [ynca.connection] < @NETRADIO:PLAYBACKINFO=?
+2022-07-16 20:35:27 DEBUG (Thread-3) [ynca.connection] > @NETRADIO:PLAYBACKINFO=Stop
+2022-07-16 20:35:27 DEBUG (Thread-4) [ynca.connection] < @NETRADIO:STATION=?
+2022-07-16 20:35:27 DEBUG (Thread-3) [ynca.connection] > @NETRADIO:STATION=
+2022-07-16 20:35:27 DEBUG (Thread-4) [ynca.connection] < @SYS:VERSION=?
+2022-07-16 20:35:27 DEBUG (Thread-3) [ynca.connection] > @SYS:VERSION=1.80/2.01
+2022-07-16 20:35:27 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.NETRADIO initialization done.
+2022-07-16 20:35:27 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.PC initialization start.
+2022-07-16 20:35:28 DEBUG (Thread-4) [ynca.connection] < @PC:AVAIL=?
+2022-07-16 20:35:28 DEBUG (Thread-3) [ynca.connection] > @PC:AVAIL=Not Ready
+2022-07-16 20:35:28 DEBUG (Thread-4) [ynca.connection] < @PC:PLAYBACKINFO=?
+2022-07-16 20:35:28 DEBUG (Thread-3) [ynca.connection] > @PC:PLAYBACKINFO=Stop
+2022-07-16 20:35:28 DEBUG (Thread-4) [ynca.connection] < @PC:METAINFO=?
+2022-07-16 20:35:28 DEBUG (Thread-3) [ynca.connection] > @PC:ARTIST=
+2022-07-16 20:35:28 DEBUG (Thread-3) [ynca.connection] > @PC:ALBUM=
+2022-07-16 20:35:28 DEBUG (Thread-3) [ynca.connection] > @PC:SONG=
+2022-07-16 20:35:28 DEBUG (Thread-4) [ynca.connection] < @PC:REPEAT=?
+2022-07-16 20:35:28 DEBUG (Thread-3) [ynca.connection] > @PC:REPEAT=Off
+2022-07-16 20:35:28 DEBUG (Thread-4) [ynca.connection] < @PC:SHUFFLE=?
+2022-07-16 20:35:28 DEBUG (Thread-3) [ynca.connection] > @PC:SHUFFLE=On
+2022-07-16 20:35:28 DEBUG (Thread-4) [ynca.connection] < @SYS:VERSION=?
+2022-07-16 20:35:28 DEBUG (Thread-3) [ynca.connection] > @SYS:VERSION=1.80/2.01
+2022-07-16 20:35:28 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.PC initialization done.
+2022-07-16 20:35:28 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.TUN initialization start.
+2022-07-16 20:35:28 DEBUG (Thread-4) [ynca.connection] < @TUN:AVAIL=?
+2022-07-16 20:35:28 DEBUG (Thread-3) [ynca.connection] > @TUN:AVAIL=Not Ready
+2022-07-16 20:35:28 DEBUG (Thread-4) [ynca.connection] < @TUN:BAND=?
+2022-07-16 20:35:28 DEBUG (Thread-3) [ynca.connection] > @TUN:BAND=FM
+2022-07-16 20:35:28 DEBUG (Thread-4) [ynca.connection] < @TUN:AMFREQ=?
+2022-07-16 20:35:28 DEBUG (Thread-3) [ynca.connection] > @TUN:AMFREQ=1080
+2022-07-16 20:35:28 DEBUG (Thread-4) [ynca.connection] < @TUN:FMFREQ=?
+2022-07-16 20:35:28 DEBUG (Thread-3) [ynca.connection] > @TUN:FMFREQ=90.40
+2022-07-16 20:35:29 DEBUG (Thread-4) [ynca.connection] < @SYS:VERSION=?
+2022-07-16 20:35:29 DEBUG (Thread-3) [ynca.connection] > @SYS:VERSION=1.80/2.01
+2022-07-16 20:35:29 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.TUN initialization done.
+2022-07-16 20:35:29 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.UAW initialization start.
+2022-07-16 20:35:29 DEBUG (Thread-4) [ynca.connection] < @UAW:AVAIL=?
+2022-07-16 20:35:29 DEBUG (Thread-3) [ynca.connection] > @UAW:AVAIL=Not Connected
+2022-07-16 20:35:29 DEBUG (Thread-4) [ynca.connection] < @SYS:VERSION=?
+2022-07-16 20:35:29 DEBUG (Thread-3) [ynca.connection] > @SYS:VERSION=1.80/2.01
+2022-07-16 20:35:29 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.UAW initialization done.
+2022-07-16 20:35:29 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.USB initialization start.
+2022-07-16 20:35:29 DEBUG (Thread-4) [ynca.connection] < @USB:AVAIL=?
+2022-07-16 20:35:29 DEBUG (Thread-3) [ynca.connection] > @USB:AVAIL=Not Connected
+2022-07-16 20:35:29 DEBUG (Thread-4) [ynca.connection] < @USB:PLAYBACKINFO=?
+2022-07-16 20:35:29 DEBUG (Thread-3) [ynca.connection] > @USB:PLAYBACKINFO=Stop
+2022-07-16 20:35:29 DEBUG (Thread-4) [ynca.connection] < @USB:METAINFO=?
+2022-07-16 20:35:29 DEBUG (Thread-3) [ynca.connection] > @USB:ARTIST=
+2022-07-16 20:35:29 DEBUG (Thread-3) [ynca.connection] > @USB:ALBUM=
+2022-07-16 20:35:29 DEBUG (Thread-3) [ynca.connection] > @USB:SONG=
+2022-07-16 20:35:29 DEBUG (Thread-4) [ynca.connection] < @USB:REPEAT=?
+2022-07-16 20:35:29 DEBUG (Thread-3) [ynca.connection] > @USB:REPEAT=Off
+2022-07-16 20:35:29 DEBUG (Thread-4) [ynca.connection] < @USB:SHUFFLE=?
+2022-07-16 20:35:29 DEBUG (Thread-3) [ynca.connection] > @USB:SHUFFLE=On
+2022-07-16 20:35:29 DEBUG (Thread-4) [ynca.connection] < @SYS:VERSION=?
+2022-07-16 20:35:29 DEBUG (Thread-3) [ynca.connection] > @SYS:VERSION=1.80/2.01
+2022-07-16 20:35:29 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.USB initialization done.
+2022-07-16 20:35:29 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.ZONE2 initialization start.
+2022-07-16 20:35:29 DEBUG (Thread-4) [ynca.connection] < @ZONE2:AVAIL=?
+2022-07-16 20:35:29 DEBUG (Thread-3) [ynca.connection] > @ZONE2:AVAIL=Not Ready
+2022-07-16 20:35:30 DEBUG (Thread-4) [ynca.connection] < @ZONE2:PWR=?
+2022-07-16 20:35:30 DEBUG (Thread-3) [ynca.connection] > @ZONE2:PWR=Standby
+2022-07-16 20:35:30 DEBUG (Thread-4) [ynca.connection] < @ZONE2:BASIC=?
+2022-07-16 20:35:30 DEBUG (Thread-3) [ynca.connection] > @ZONE2:PWR=Standby
+2022-07-16 20:35:30 DEBUG (Thread-3) [ynca.connection] > @ZONE2:SLEEP=Off
+2022-07-16 20:35:30 DEBUG (Thread-3) [ynca.connection] > @ZONE2:VOL=2.5
+2022-07-16 20:35:30 DEBUG (Thread-3) [ynca.connection] > @ZONE2:MUTE=Off
+2022-07-16 20:35:30 DEBUG (Thread-3) [ynca.connection] > @ZONE2:INP=PC
+2022-07-16 20:35:30 DEBUG (Thread-4) [ynca.connection] < @ZONE2:MAXVOL=?
+2022-07-16 20:35:30 DEBUG (Thread-3) [ynca.connection] > @ZONE2:MAXVOL=16.5
+2022-07-16 20:35:30 DEBUG (Thread-4) [ynca.connection] < @ZONE2:SCENENAME=?
+2022-07-16 20:35:30 DEBUG (Thread-3) [ynca.connection] > @RESTRICTED
+2022-07-16 20:35:30 DEBUG (Thread-4) [ynca.connection] < @ZONE2:ZONENAME=?
+2022-07-16 20:35:30 DEBUG (Thread-3) [ynca.connection] > @ZONE2:ZONENAME=Zone2   ß
+2022-07-16 20:35:30 DEBUG (Thread-4) [ynca.connection] < @SYS:VERSION=?
+2022-07-16 20:35:30 DEBUG (Thread-3) [ynca.connection] > @SYS:VERSION=1.80/2.01
+2022-07-16 20:35:30 DEBUG (SyncWorker_0) [ynca.subunit] Subunit Subunit.ZONE2 initialization done.

--- a/logs/TSR-700.txt
+++ b/logs/TSR-700.txt
@@ -1,0 +1,262 @@
+[core-ssh config]$ tail -f home-assistant.log | grep ynca
+2022-07-15 17:46:40 DEBUG (Thread-3) [ynca.connection] Connected
+2022-07-15 17:46:40 DEBUG (Thread-4 (_send_handler)) [ynca.connection] < @SYS:MODELNAME=?
+2022-07-15 17:46:40 DEBUG (Thread-3) [ynca.connection] > @SYS:MODELNAME=TSR-700
+2022-07-15 17:46:40 DEBUG (Thread-4 (_send_handler)) [ynca.connection] < @SYS:MODELNAME=?
+2022-07-15 17:46:40 DEBUG (Thread-3) [ynca.connection] > @SYS:MODELNAME=TSR-700
+2022-07-15 17:46:40 DEBUG (Thread-4 (_send_handler)) [ynca.connection] < @SYS:MODELNAME=?
+2022-07-15 17:46:40 DEBUG (Thread-3) [ynca.connection] > @SYS:MODELNAME=TSR-700
+2022-07-15 17:46:41 DEBUG (Thread-3) [ynca.connection] Connection closed/lost
+2022-07-15 17:46:42 INFO (MainThread) [homeassistant.setup] Setting up yamaha_ynca
+2022-07-15 17:46:42 INFO (MainThread) [homeassistant.setup] Setup of domain yamaha_ynca took 0.0 seconds
+2022-07-15 17:46:42 DEBUG (Thread-5) [ynca.connection] Connected
+2022-07-15 17:46:42 DEBUG (SyncWorker_4) [ynca.ynca] Subunit availability check start
+2022-07-15 17:46:42 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:MODELNAME=?
+2022-07-15 17:46:42 DEBUG (Thread-5) [ynca.connection] > @SYS:MODELNAME=TSR-700
+2022-07-15 17:46:42 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:MODELNAME=?
+2022-07-15 17:46:42 DEBUG (Thread-5) [ynca.connection] > @SYS:MODELNAME=TSR-700
+2022-07-15 17:46:42 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:AVAIL=?
+2022-07-15 17:46:42 DEBUG (Thread-5) [ynca.connection] > @UNDEFINED
+2022-07-15 17:46:42 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @MAIN:AVAIL=?
+2022-07-15 17:46:42 DEBUG (Thread-5) [ynca.connection] > @MAIN:AVAIL=Ready
+2022-07-15 17:46:42 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @ZONE2:AVAIL=?
+2022-07-15 17:46:42 DEBUG (Thread-5) [ynca.connection] > @ZONE2:AVAIL=Ready
+2022-07-15 17:46:42 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @ZONE3:AVAIL=?
+2022-07-15 17:46:42 DEBUG (Thread-5) [ynca.connection] > @RESTRICTED
+2022-07-15 17:46:42 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @ZONE4:AVAIL=?
+2022-07-15 17:46:42 DEBUG (Thread-5) [ynca.connection] > @RESTRICTED
+2022-07-15 17:46:42 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @TUN:AVAIL=?
+2022-07-15 17:46:42 DEBUG (Thread-5) [ynca.connection] > @TUN:AVAIL=Not Ready
+2022-07-15 17:46:42 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SIRIUS:AVAIL=?
+2022-07-15 17:46:42 DEBUG (Thread-5) [ynca.connection] > @UNDEFINED
+2022-07-15 17:46:43 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @IPOD:AVAIL=?
+2022-07-15 17:46:43 DEBUG (Thread-5) [ynca.connection] > @UNDEFINED
+2022-07-15 17:46:43 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @BT:AVAIL=?
+2022-07-15 17:46:43 DEBUG (Thread-5) [ynca.connection] > @BT:AVAIL=Not Ready
+2022-07-15 17:46:43 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @RHAP:AVAIL=?
+2022-07-15 17:46:43 DEBUG (Thread-5) [ynca.connection] > @UNDEFINED
+2022-07-15 17:46:43 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SIRIUSIR:AVAIL=?
+2022-07-15 17:46:43 DEBUG (Thread-5) [ynca.connection] > @UNDEFINED
+2022-07-15 17:46:43 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @PANDORA:AVAIL=?
+2022-07-15 17:46:43 DEBUG (Thread-5) [ynca.connection] > @PANDORA:AVAIL=Not Ready
+2022-07-15 17:46:43 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @NAPSTER:AVAIL=?
+2022-07-15 17:46:43 DEBUG (Thread-5) [ynca.connection] > @NAPSTER:AVAIL=Not Ready
+2022-07-15 17:46:43 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @PC:AVAIL=?
+2022-07-15 17:46:43 DEBUG (Thread-5) [ynca.connection] > @UNDEFINED
+2022-07-15 17:46:43 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @NETRADIO:AVAIL=?
+2022-07-15 17:46:43 DEBUG (Thread-5) [ynca.connection] > @NETRADIO:AVAIL=Not Ready
+2022-07-15 17:46:43 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @USB:AVAIL=?
+2022-07-15 17:46:43 DEBUG (Thread-5) [ynca.connection] > @USB:AVAIL=Not Ready
+2022-07-15 17:46:43 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @IPODUSB:AVAIL=?
+2022-07-15 17:46:43 DEBUG (Thread-5) [ynca.connection] > @UNDEFINED
+2022-07-15 17:46:44 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @UAW:AVAIL=?
+2022-07-15 17:46:44 DEBUG (Thread-5) [ynca.connection] > @UNDEFINED
+2022-07-15 17:46:44 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SIRIUSXM:AVAIL=?
+2022-07-15 17:46:44 DEBUG (Thread-5) [ynca.connection] > @SIRIUSXM:AVAIL=Not Ready
+2022-07-15 17:46:44 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SPOTIFY:AVAIL=?
+2022-07-15 17:46:44 DEBUG (Thread-5) [ynca.connection] > @SPOTIFY:AVAIL=Not Ready
+2022-07-15 17:46:44 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SERVER:AVAIL=?
+2022-07-15 17:46:44 DEBUG (Thread-5) [ynca.connection] > @SERVER:AVAIL=Not Ready
+2022-07-15 17:46:44 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @AIRPLAY:AVAIL=?
+2022-07-15 17:46:44 DEBUG (Thread-5) [ynca.connection] > @AIRPLAY:AVAIL=Not Ready
+2022-07-15 17:46:44 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:VERSION=?
+2022-07-15 17:46:44 DEBUG (Thread-5) [ynca.connection] > @SYS:VERSION=1.53/3.12
+2022-07-15 17:46:44 DEBUG (SyncWorker_4) [ynca.ynca] Subunit availability check done
+2022-07-15 17:46:44 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.SYS initialization start.
+2022-07-15 17:46:44 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:AVAIL=?
+2022-07-15 17:46:44 DEBUG (Thread-5) [ynca.connection] > @UNDEFINED
+2022-07-15 17:46:44 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:PWR=?
+2022-07-15 17:46:44 DEBUG (Thread-5) [ynca.connection] > @SYS:PWR=On
+2022-07-15 17:46:44 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:MODELNAME=?
+2022-07-15 17:46:44 DEBUG (Thread-5) [ynca.connection] > @SYS:MODELNAME=TSR-700
+2022-07-15 17:46:44 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:INPNAME=?
+2022-07-15 17:46:44 DEBUG (Thread-5) [ynca.connection] > @UNDEFINED
+2022-07-15 17:46:45 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:VERSION=?
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @SYS:VERSION=1.53/3.12
+2022-07-15 17:46:45 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.SYS initialization done.
+2022-07-15 17:46:45 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.AIRPLAY initialization start.
+2022-07-15 17:46:45 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @AIRPLAY:AVAIL=?
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @AIRPLAY:AVAIL=Not Ready
+2022-07-15 17:46:45 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:VERSION=?
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @SYS:VERSION=1.53/3.12
+2022-07-15 17:46:45 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.AIRPLAY initialization done.
+2022-07-15 17:46:45 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.BT initialization start.
+2022-07-15 17:46:45 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @BT:AVAIL=?
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @BT:AVAIL=Not Ready
+2022-07-15 17:46:45 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:VERSION=?
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @SYS:VERSION=1.53/3.12
+2022-07-15 17:46:45 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.BT initialization done.
+2022-07-15 17:46:45 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.MAIN initialization start.
+2022-07-15 17:46:45 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @MAIN:AVAIL=?
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @MAIN:AVAIL=Ready
+2022-07-15 17:46:45 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @MAIN:PWR=?
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @MAIN:PWR=On
+2022-07-15 17:46:45 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @MAIN:BASIC=?
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @MAIN:PWR=On
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @MAIN:SLEEP=Off
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @MAIN:VOL=-24.0
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @MAIN:MUTE=Off
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @MAIN:INP=HDMI1
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @MAIN:STRAIGHT=Off
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @MAIN:ENHANCER=Off
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @MAIN:SOUNDPRG=All-Ch Stereo
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @MAIN:TONEBASS=2.5
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @MAIN:TONETREBLE=1.0
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @MAIN:PUREDIRMODE=Off
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @SYS:HDMIOUT1=On
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @MAIN:EXBASS=Off
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @MAIN:ADAPTIVEDRC=Off
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @MAIN:DIALOGUELVL=3
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @MAIN:DTSDIALOGUECONTROL=4
+2022-07-15 17:46:45 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @MAIN:MAXVOL=?
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @UNDEFINED
+2022-07-15 17:46:45 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @MAIN:SCENENAME=?
+2022-07-15 17:46:45 DEBUG (Thread-5) [ynca.connection] > @UNDEFINED
+2022-07-15 17:46:46 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @MAIN:ZONENAME=?
+2022-07-15 17:46:46 DEBUG (Thread-5) [ynca.connection] > @UNDEFINED
+2022-07-15 17:46:46 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:VERSION=?
+2022-07-15 17:46:46 DEBUG (Thread-5) [ynca.connection] > @SYS:VERSION=1.53/3.12
+2022-07-15 17:46:46 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.MAIN initialization done.
+2022-07-15 17:46:46 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.NAPSTER initialization start.
+2022-07-15 17:46:46 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @NAPSTER:AVAIL=?
+2022-07-15 17:46:46 DEBUG (Thread-5) [ynca.connection] > @NAPSTER:AVAIL=Not Ready
+2022-07-15 17:46:46 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @NAPSTER:PLAYBACKINFO=?
+2022-07-15 17:46:46 DEBUG (Thread-5) [ynca.connection] > @NAPSTER:PLAYBACKINFO=Stop
+2022-07-15 17:46:46 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @NAPSTER:METAINFO=?
+2022-07-15 17:46:46 DEBUG (Thread-5) [ynca.connection] > @NAPSTER:ARTIST=
+2022-07-15 17:46:46 DEBUG (Thread-5) [ynca.connection] > @NAPSTER:ALBUM=
+2022-07-15 17:46:46 DEBUG (Thread-5) [ynca.connection] > @NAPSTER:SONG=
+2022-07-15 17:46:46 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @NAPSTER:REPEAT=?
+2022-07-15 17:46:46 DEBUG (Thread-5) [ynca.connection] > @NAPSTER:REPEAT=Off
+2022-07-15 17:46:46 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @NAPSTER:SHUFFLE=?
+2022-07-15 17:46:46 DEBUG (Thread-5) [ynca.connection] > @NAPSTER:SHUFFLE=Off
+2022-07-15 17:46:46 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:VERSION=?
+2022-07-15 17:46:46 DEBUG (Thread-5) [ynca.connection] > @SYS:VERSION=1.53/3.12
+2022-07-15 17:46:46 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.NAPSTER initialization done.
+2022-07-15 17:46:46 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.NETRADIO initialization start.
+2022-07-15 17:46:46 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @NETRADIO:AVAIL=?
+2022-07-15 17:46:46 DEBUG (Thread-5) [ynca.connection] > @NETRADIO:AVAIL=Not Ready
+2022-07-15 17:46:47 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @NETRADIO:PLAYBACKINFO=?
+2022-07-15 17:46:47 DEBUG (Thread-5) [ynca.connection] > @NETRADIO:PLAYBACKINFO=Stop
+2022-07-15 17:46:47 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @NETRADIO:STATION=?
+2022-07-15 17:46:47 DEBUG (Thread-5) [ynca.connection] > @NETRADIO:STATION=
+2022-07-15 17:46:47 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:VERSION=?
+2022-07-15 17:46:47 DEBUG (Thread-5) [ynca.connection] > @SYS:VERSION=1.53/3.12
+2022-07-15 17:46:47 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.NETRADIO initialization done.
+2022-07-15 17:46:47 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.PANDORA initialization start.
+2022-07-15 17:46:47 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @PANDORA:AVAIL=?
+2022-07-15 17:46:47 DEBUG (Thread-5) [ynca.connection] > @PANDORA:AVAIL=Not Ready
+2022-07-15 17:46:47 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @PANDORA:PLAYBACKINFO=?
+2022-07-15 17:46:47 DEBUG (Thread-5) [ynca.connection] > @PANDORA:PLAYBACKINFO=Stop
+2022-07-15 17:46:47 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @PANDORA:METAINFO=?
+2022-07-15 17:46:47 DEBUG (Thread-5) [ynca.connection] > @PANDORA:TRACK=
+2022-07-15 17:46:47 DEBUG (Thread-5) [ynca.connection] > @PANDORA:ALBUM=
+2022-07-15 17:46:47 DEBUG (Thread-5) [ynca.connection] > @PANDORA:STATION=
+2022-07-15 17:46:47 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @PANDORA:STATION=?
+2022-07-15 17:46:47 DEBUG (Thread-5) [ynca.connection] > @PANDORA:STATION=
+2022-07-15 17:46:47 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:VERSION=?
+2022-07-15 17:46:47 DEBUG (Thread-5) [ynca.connection] > @SYS:VERSION=1.53/3.12
+2022-07-15 17:46:47 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.PANDORA initialization done.
+2022-07-15 17:46:47 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.SERVER initialization start.
+2022-07-15 17:46:47 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SERVER:AVAIL=?
+2022-07-15 17:46:47 DEBUG (Thread-5) [ynca.connection] > @SERVER:AVAIL=Not Ready
+2022-07-15 17:46:47 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SERVER:PLAYBACKINFO=?
+2022-07-15 17:46:47 DEBUG (Thread-5) [ynca.connection] > @SERVER:PLAYBACKINFO=Stop
+2022-07-15 17:46:48 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SERVER:METAINFO=?
+2022-07-15 17:46:48 DEBUG (Thread-5) [ynca.connection] > @SERVER:ARTIST=
+2022-07-15 17:46:48 DEBUG (Thread-5) [ynca.connection] > @SERVER:ALBUM=
+2022-07-15 17:46:48 DEBUG (Thread-5) [ynca.connection] > @SERVER:SONG=
+2022-07-15 17:46:48 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SERVER:REPEAT=?
+2022-07-15 17:46:48 DEBUG (Thread-5) [ynca.connection] > @SERVER:REPEAT=Off
+2022-07-15 17:46:48 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SERVER:SHUFFLE=?
+2022-07-15 17:46:48 DEBUG (Thread-5) [ynca.connection] > @SERVER:SHUFFLE=Off
+2022-07-15 17:46:48 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:VERSION=?
+2022-07-15 17:46:48 DEBUG (Thread-5) [ynca.connection] > @SYS:VERSION=1.53/3.12
+2022-07-15 17:46:48 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.SERVER initialization done.
+2022-07-15 17:46:48 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.SIRIUSXM initialization start.
+2022-07-15 17:46:48 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SIRIUSXM:AVAIL=?
+2022-07-15 17:46:48 DEBUG (Thread-5) [ynca.connection] > @SIRIUSXM:AVAIL=Not Ready
+2022-07-15 17:46:48 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:VERSION=?
+2022-07-15 17:46:48 DEBUG (Thread-5) [ynca.connection] > @SYS:VERSION=1.53/3.12
+2022-07-15 17:46:48 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.SIRIUSXM initialization done.
+2022-07-15 17:46:48 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.SPOTIFY initialization start.
+2022-07-15 17:46:48 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SPOTIFY:AVAIL=?
+2022-07-15 17:46:48 DEBUG (Thread-5) [ynca.connection] > @SPOTIFY:AVAIL=Not Ready
+2022-07-15 17:46:48 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SPOTIFY:PLAYBACKINFO=?
+2022-07-15 17:46:48 DEBUG (Thread-5) [ynca.connection] > @SPOTIFY:PLAYBACKINFO=Stop
+2022-07-15 17:46:48 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SPOTIFY:METAINFO=?
+2022-07-15 17:46:48 DEBUG (Thread-5) [ynca.connection] > @SPOTIFY:ARTIST=
+2022-07-15 17:46:48 DEBUG (Thread-5) [ynca.connection] > @SPOTIFY:ALBUM=
+2022-07-15 17:46:48 DEBUG (Thread-5) [ynca.connection] > @SPOTIFY:TRACK=
+2022-07-15 17:46:48 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SPOTIFY:REPEAT=?
+2022-07-15 17:46:48 DEBUG (Thread-5) [ynca.connection] > @SPOTIFY:REPEAT=Off
+2022-07-15 17:46:49 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SPOTIFY:SHUFFLE=?
+2022-07-15 17:46:49 DEBUG (Thread-5) [ynca.connection] > @SPOTIFY:SHUFFLE=Off
+2022-07-15 17:46:49 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:VERSION=?
+2022-07-15 17:46:49 DEBUG (Thread-5) [ynca.connection] > @SYS:VERSION=1.53/3.12
+2022-07-15 17:46:49 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.SPOTIFY initialization done.
+2022-07-15 17:46:49 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.TUN initialization start.
+2022-07-15 17:46:49 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @TUN:AVAIL=?
+2022-07-15 17:46:49 DEBUG (Thread-5) [ynca.connection] > @TUN:AVAIL=Not Ready
+2022-07-15 17:46:49 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @TUN:BAND=?
+2022-07-15 17:46:49 DEBUG (Thread-5) [ynca.connection] > @TUN:BAND=FM
+2022-07-15 17:46:49 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @TUN:AMFREQ=?
+2022-07-15 17:46:49 DEBUG (Thread-5) [ynca.connection] > @TUN:AMFREQ=1080
+2022-07-15 17:46:49 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @TUN:FMFREQ=?
+2022-07-15 17:46:49 DEBUG (Thread-5) [ynca.connection] > @TUN:FMFREQ=98.10
+2022-07-15 17:46:49 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:VERSION=?
+2022-07-15 17:46:49 DEBUG (Thread-5) [ynca.connection] > @SYS:VERSION=1.53/3.12
+2022-07-15 17:46:49 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.TUN initialization done.
+2022-07-15 17:46:49 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.USB initialization start.
+2022-07-15 17:46:49 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @USB:AVAIL=?
+2022-07-15 17:46:49 DEBUG (Thread-5) [ynca.connection] > @USB:AVAIL=Not Ready
+2022-07-15 17:46:49 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @USB:PLAYBACKINFO=?
+2022-07-15 17:46:49 DEBUG (Thread-5) [ynca.connection] > @USB:PLAYBACKINFO=Stop
+2022-07-15 17:46:49 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @USB:METAINFO=?
+2022-07-15 17:46:49 DEBUG (Thread-5) [ynca.connection] > @USB:ARTIST=
+2022-07-15 17:46:49 DEBUG (Thread-5) [ynca.connection] > @USB:ALBUM=
+2022-07-15 17:46:49 DEBUG (Thread-5) [ynca.connection] > @USB:SONG=
+2022-07-15 17:46:50 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @USB:REPEAT=?
+2022-07-15 17:46:50 DEBUG (Thread-5) [ynca.connection] > @USB:REPEAT=Off
+2022-07-15 17:46:50 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @USB:SHUFFLE=?
+2022-07-15 17:46:50 DEBUG (Thread-5) [ynca.connection] > @USB:SHUFFLE=Off
+2022-07-15 17:46:50 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:VERSION=?
+2022-07-15 17:46:50 DEBUG (Thread-5) [ynca.connection] > @SYS:VERSION=1.53/3.12
+2022-07-15 17:46:50 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.USB initialization done.
+2022-07-15 17:46:50 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.ZONE2 initialization start.
+2022-07-15 17:46:50 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @ZONE2:AVAIL=?
+2022-07-15 17:46:50 DEBUG (Thread-5) [ynca.connection] > @ZONE2:AVAIL=Ready
+2022-07-15 17:46:50 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @ZONE2:PWR=?
+2022-07-15 17:46:50 DEBUG (Thread-5) [ynca.connection] > @ZONE2:PWR=On
+2022-07-15 17:46:50 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @ZONE2:BASIC=?
+2022-07-15 17:46:50 DEBUG (Thread-5) [ynca.connection] > @ZONE2:PWR=On
+2022-07-15 17:46:50 DEBUG (Thread-5) [ynca.connection] > @ZONE2:SLEEP=Off
+2022-07-15 17:46:50 DEBUG (Thread-5) [ynca.connection] > @ZONE2:VOL=-40.0
+2022-07-15 17:46:50 DEBUG (Thread-5) [ynca.connection] > @ZONE2:MUTE=Off
+2022-07-15 17:46:50 DEBUG (Thread-5) [ynca.connection] > @ZONE2:INP=AUDIO1
+2022-07-15 17:46:50 DEBUG (Thread-5) [ynca.connection] > @ZONE2:TONEMODE=Auto
+2022-07-15 17:46:50 DEBUG (Thread-5) [ynca.connection] > @ZONE2:TONEBASS=0.0
+2022-07-15 17:46:50 DEBUG (Thread-5) [ynca.connection] > @ZONE2:TONETREBLE=0.0
+2022-07-15 17:46:50 DEBUG (Thread-5) [ynca.connection] > @ZONE2:EXBASS=Off
+2022-07-15 17:46:50 DEBUG (Thread-5) [ynca.connection] > @ZONE2:ENHANCER=On
+2022-07-15 17:46:50 DEBUG (Thread-5) [ynca.connection] > @MAIN:PUREDIRMODE=Off
+2022-07-15 17:46:50 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @ZONE2:MAXVOL=?
+2022-07-15 17:46:50 DEBUG (Thread-5) [ynca.connection] > @UNDEFINED
+2022-07-15 17:46:50 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @ZONE2:SCENENAME=?
+2022-07-15 17:46:50 DEBUG (Thread-5) [ynca.connection] > @UNDEFINED
+2022-07-15 17:46:50 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @ZONE2:ZONENAME=?
+2022-07-15 17:46:50 DEBUG (Thread-5) [ynca.connection] > @UNDEFINED
+2022-07-15 17:46:50 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:VERSION=?
+2022-07-15 17:46:50 DEBUG (Thread-5) [ynca.connection] > @SYS:VERSION=1.53/3.12
+2022-07-15 17:46:50 DEBUG (SyncWorker_4) [ynca.subunit] Subunit Subunit.ZONE2 initialization done.
+2022-07-15 17:46:50 INFO (MainThread) [homeassistant.components.media_player] Setting up media_player.yamaha_ynca
+2022-07-15 17:46:50 INFO (MainThread) [homeassistant.components.button] Setting up button.yamaha_ynca
+2022-07-15 17:46:50 INFO (MainThread) [homeassistant.helpers.entity_registry] Registered new media_player.yamaha_ynca entity: media_player.yamaha_ynca_071659cf96f0c7af509dd36ed2c9aefe_zone2
+2022-07-15 17:46:50 ERROR (MainThread) [homeassistant.components.media_player] Error adding entities for domain media_player with platform yamaha_ynca
+  File "/config/custom_components/yamaha_ynca/media_player.py", line 218, in supported_features
+  File "/usr/local/lib/python3.10/site-packages/ynca/zone.py", line 137, in soundprg
+2022-07-15 17:46:50 ERROR (MainThread) [homeassistant.components.media_player] Error while setting up yamaha_ynca platform for media_player
+  File "/config/custom_components/yamaha_ynca/media_player.py", line 218, in supported_features
+  File "/usr/local/lib/python3.10/site-packages/ynca/zone.py", line 137, in soundprg
+2022-07-15 17:47:21 DEBUG (Thread-6 (_send_handler)) [ynca.connection] < @SYS:MODELNAME=?
+2022-07-15 17:47:21 DEBUG (Thread-5) [ynca.connection] > @SYS:MODELNAME=TSR-700

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,3 @@
 pytest>=7.0.0
 pytest-mock
+pytest-cov

--- a/tests/test_modelinfo.py
+++ b/tests/test_modelinfo.py
@@ -1,0 +1,16 @@
+from ynca.constants import SoundPrg
+from ynca.modelinfo import get_modelinfo, ModelInfo
+
+
+def test_no_modelinfo():
+    assert get_modelinfo("unknown") is None
+
+
+def test_modelinfo():
+    rx2000 = get_modelinfo("RX-A2000")
+    assert isinstance(rx2000, ModelInfo)
+    assert SoundPrg.CHURCH_IN_FREIBURG in rx2000.soundprg
+
+    rx2020 = get_modelinfo("RX-A2020")
+    assert SoundPrg.SEVEN_CH_STEREO not in rx2020.soundprg
+    assert SoundPrg.NINE_CH_STEREO in rx2020.soundprg

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -86,7 +86,7 @@ def test_initialize_minimal(connection, update_callback):
     assert s.version == "Version"
     assert s.pwr is None
     assert s.modelname is None
-    assert len(s.inputs.keys()) == 0
+    assert len(s.inp_names.keys()) == 0
 
 
 def test_initialize_full(connection, update_callback):
@@ -103,26 +103,26 @@ def test_initialize_full(connection, update_callback):
     assert s.modelname == "ModelName"
     assert s.pwr is False
 
-    assert len(s.inputs.keys()) == 19
-    assert s.inputs["PHONO"] == "InputPhono"
-    assert s.inputs["HDMI1"] == "InputHdmi1"
-    assert s.inputs["HDMI2"] == "InputHdmi2"
-    assert s.inputs["HDMI3"] == "InputHdmi3"
-    assert s.inputs["HDMI4"] == "InputHdmi4"
-    assert s.inputs["HDMI5"] == "InputHdmi5"
-    assert s.inputs["HDMI6"] == "InputHdmi6"
-    assert s.inputs["HDMI7"] == "InputHdmi7"
-    assert s.inputs["AV1"] == "InputAv1"
-    assert s.inputs["AV2"] == "InputAv2"
-    assert s.inputs["AV3"] == "InputAv3"
-    assert s.inputs["AV4"] == "InputAv4"
-    assert s.inputs["AV5"] == "InputAv5"
-    assert s.inputs["AV6"] == "InputAv6"
-    assert s.inputs["V-AUX"] == "InputVAux"
-    assert s.inputs["AUDIO1"] == "InputAudio1"
-    assert s.inputs["AUDIO2"] == "InputAudio2"
-    assert s.inputs["DOCK"] == "InputDock"
-    assert s.inputs["USB"] == "InputUsb"
+    assert len(s.inp_names.keys()) == 19
+    assert s.inp_names["PHONO"] == "InputPhono"
+    assert s.inp_names["HDMI1"] == "InputHdmi1"
+    assert s.inp_names["HDMI2"] == "InputHdmi2"
+    assert s.inp_names["HDMI3"] == "InputHdmi3"
+    assert s.inp_names["HDMI4"] == "InputHdmi4"
+    assert s.inp_names["HDMI5"] == "InputHdmi5"
+    assert s.inp_names["HDMI6"] == "InputHdmi6"
+    assert s.inp_names["HDMI7"] == "InputHdmi7"
+    assert s.inp_names["AV1"] == "InputAv1"
+    assert s.inp_names["AV2"] == "InputAv2"
+    assert s.inp_names["AV3"] == "InputAv3"
+    assert s.inp_names["AV4"] == "InputAv4"
+    assert s.inp_names["AV5"] == "InputAv5"
+    assert s.inp_names["AV6"] == "InputAv6"
+    assert s.inp_names["V-AUX"] == "InputVAux"
+    assert s.inp_names["AUDIO1"] == "InputAudio1"
+    assert s.inp_names["AUDIO2"] == "InputAudio2"
+    assert s.inp_names["DOCK"] == "InputDock"
+    assert s.inp_names["USB"] == "InputUsb"
 
 
 def test_registration(connection, initialized_system):

--- a/tests/test_ynca.py
+++ b/tests/test_ynca.py
@@ -4,6 +4,7 @@ import pytest
 import ynca
 from ynca.bt import Bt
 from ynca.errors import YncaConnectionError, YncaInitializationFailedException
+from ynca.get_all_zone_inputs import FALLBACK_INPUTS
 from ynca.system import System
 from ynca.zone import Main
 
@@ -216,6 +217,9 @@ def test_initialize_minimal(connection):
 
         assert isinstance(y.SYS, System)
         assert y.SYS.version == "Version"
+
+        inputs = ynca.get_all_zone_inputs(y)
+        assert inputs == FALLBACK_INPUTS
 
         y.close()
 

--- a/tests/test_ynca.py
+++ b/tests/test_ynca.py
@@ -307,7 +307,7 @@ def test_initialize_full(connection):
         assert y.SYS.version == "Version"
 
         assert isinstance(y.MAIN, Main)
-        assert y.MAIN.name == "MainZoneName"
+        assert y.MAIN.zonename == "MainZoneName"
         assert isinstance(y.BT, Bt)
         assert y.ZONE2 is None
         assert y.ZONE3 is None
@@ -359,7 +359,7 @@ def test_initialize_full_deprecated_receiver(connection):
         assert y.SYS.version == "Version"
 
         assert isinstance(y.MAIN, Main)
-        assert y.MAIN.name == "MainZoneName"
+        assert y.MAIN.zonename == "MainZoneName"
         assert isinstance(y.BT, Bt)
         assert y.ZONE2 is None
         assert y.ZONE3 is None

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -138,7 +138,7 @@ def test_initialize_minimal(connection, update_callback):
     assert z.mute is None
     assert z.straight is None
     assert z.soundprg is None
-    assert len(z.scene_names.keys()) == 0
+    assert len(z.scenenames.keys()) == 0
 
 
 def test_initialize_full(connection, update_callback):
@@ -161,12 +161,12 @@ def test_initialize_full(connection, update_callback):
     assert z.soundprg == "Standard"
     assert z.zonename == "ZoneName"
 
-    assert len(z.scene_names.keys()) == 5
-    assert z.scene_names["1"] == "Scene name 1"
-    assert z.scene_names["2"] == "Scene name 2"
-    assert z.scene_names["3"] == "Scene name 3"
-    assert z.scene_names["4"] == "Scene name 4"
-    assert z.scene_names["42"] == "Scene name 42"
+    assert len(z.scenenames.keys()) == 5
+    assert z.scenenames["1"] == "Scene name 1"
+    assert z.scenenames["2"] == "Scene name 2"
+    assert z.scenenames["3"] == "Scene name 3"
+    assert z.scenenames["4"] == "Scene name 4"
+    assert z.scenenames["42"] == "Scene name 42"
 
 
 def test_mute(connection, initialized_zone):
@@ -295,7 +295,7 @@ def test_scene(connection, initialized_zone):
 
     # Updates from device
     connection.send_protocol_message(SUBUNIT, "SCENE3NAME", "New Name")
-    assert initialized_zone.scene_names["3"] == "New Name"
+    assert initialized_zone.scenenames["3"] == "New Name"
 
 
 def test_zonename(connection, initialized_zone):

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -129,7 +129,7 @@ def test_initialize_minimal(connection, update_callback):
     z.initialize()
 
     assert update_callback.call_count == 0
-    assert z.name == "ZoneName"
+    assert z.zonename == "ZoneName"
     assert z.pwr is None
     assert z.input is None
     assert z.volume is None
@@ -159,7 +159,7 @@ def test_initialize_full(connection, update_callback):
     assert z.mute is Mute.off
     assert z.straight is False
     assert z.soundprg == "Standard"
-    assert z.name == "ZoneName"
+    assert z.zonename == "ZoneName"
 
     assert len(z.scene_names.keys()) == 5
     assert z.scene_names["1"] == "Scene name 1"
@@ -296,6 +296,18 @@ def test_scene(connection, initialized_zone):
     # Updates from device
     connection.send_protocol_message(SUBUNIT, "SCENE3NAME", "New Name")
     assert initialized_zone.scene_names["3"] == "New Name"
+
+
+def test_zonename(connection, initialized_zone):
+    # Writing to device
+    initialized_zone.zonename = "new name"
+    connection.put.assert_called_with(SUBUNIT, "ZONENAME", "new name")
+    with pytest.raises(ValueError):
+        initialized_zone.zonename = "new name is too long"
+
+    # Updates from device
+    connection.send_protocol_message(SUBUNIT, "ZONENAME", "updated")
+    assert initialized_zone.zonename == "updated"
 
 
 # TODO: This seems generic and probably should be moved to the subunit test

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -138,7 +138,7 @@ def test_initialize_minimal(connection, update_callback):
     assert z.mute is None
     assert z.straight is None
     assert z.soundprg is None
-    assert len(z.scenes.keys()) == 0
+    assert len(z.scene_names.keys()) == 0
 
 
 def test_initialize_full(connection, update_callback):
@@ -161,12 +161,12 @@ def test_initialize_full(connection, update_callback):
     assert z.soundprg == "Standard"
     assert z.name == "ZoneName"
 
-    assert len(z.scenes.keys()) == 5
-    assert z.scenes["1"] == "Scene name 1"
-    assert z.scenes["2"] == "Scene name 2"
-    assert z.scenes["3"] == "Scene name 3"
-    assert z.scenes["4"] == "Scene name 4"
-    assert z.scenes["42"] == "Scene name 42"
+    assert len(z.scene_names.keys()) == 5
+    assert z.scene_names["1"] == "Scene name 1"
+    assert z.scene_names["2"] == "Scene name 2"
+    assert z.scene_names["3"] == "Scene name 3"
+    assert z.scene_names["4"] == "Scene name 4"
+    assert z.scene_names["42"] == "Scene name 42"
 
 
 def test_mute(connection, initialized_zone):
@@ -295,7 +295,7 @@ def test_scene(connection, initialized_zone):
 
     # Updates from device
     connection.send_protocol_message(SUBUNIT, "SCENE3NAME", "New Name")
-    assert initialized_zone.scenes["3"] == "New Name"
+    assert initialized_zone.scene_names["3"] == "New Name"
 
 
 # TODO: This seems generic and probably should be moved to the subunit test

--- a/ynca/__init__.py
+++ b/ynca/__init__.py
@@ -22,4 +22,6 @@ from .ynca import (
 )
 from .receiver_deprecated import Receiver
 
+from .modelinfo import get_modelinfo
+
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/ynca/constants.py
+++ b/ynca/constants.py
@@ -5,7 +5,12 @@ from enum import Enum
 class SoundPrg(str, Enum):
     HALL_IN_MUNICH = "Hall in Munich"
     HALL_IN_VIENNA = "Hall in Vienna"
+    HALL_IN_AMSTERDAM = "Hall in Amsterdam"
+    CHURCH_IN_FREIBURG = "Church in Freiburg"
+    CHURCH_IN_ROYAUMONT = "Church in Royaumont"
     CHAMBER = "Chamber"
+    VILLAGE_VANGUARD = "Village Vanguard"
+    WAREHOUSE_LOFT = "Warehouse Loft"
     CELLAR_CLUB = "Cellar Club"
     THE_ROXY_THEATRE = "The Roxy Theatre"
     THE_BOTTOM_LINE = "The Bottom Line"
@@ -13,6 +18,7 @@ class SoundPrg(str, Enum):
     ACTION_GAME = "Action Game"
     ROLEPLAYING_GAME = "Roleplaying Game"
     MUSIC_VIDEO = "Music Video"
+    RECITAL_OPERA = "Recital/Opera"
     STANDARD = "Standard"
     SPECTACLE = "Spectacle"
     SCI_FI = "Sci-Fi"
@@ -21,9 +27,9 @@ class SoundPrg(str, Enum):
     MONO_MOVIE = "Mono Movie"
     TWO_CH_STEREO = "2ch Stereo"
     SEVEN_CH_STEREO = "7ch Stereo"
+    NINE_CH_STEREO = "9ch Stereo"
     SURROUND_DECODER = "Surround Decoder"
-    NINE_CH_STEREO = "9ch Stereo"  # Available on RX-A3010 and RX-A3020
-    ALL_CH_STEREO = "All-Ch Stereo"  # Available on TRS-700
+    ALL_CH_STEREO = "All-Ch Stereo"  # Available on TSR-700
 
 
 class Mute(str, Enum):

--- a/ynca/constants.py
+++ b/ynca/constants.py
@@ -22,7 +22,8 @@ class SoundPrg(str, Enum):
     TWO_CH_STEREO = "2ch Stereo"
     SEVEN_CH_STEREO = "7ch Stereo"
     SURROUND_DECODER = "Surround Decoder"
-    NINE_CH_STEREO = "9ch Stereo"
+    NINE_CH_STEREO = "9ch Stereo"  # Available on RX-A3010 and RX-A3020
+    ALL_CH_STEREO = "All-Ch Stereo"  # Available on TRS-700
 
 
 class Mute(str, Enum):

--- a/ynca/get_all_zone_inputs.py
+++ b/ynca/get_all_zone_inputs.py
@@ -40,7 +40,7 @@ def get_all_zone_inputs(ynca: Ynca) -> Dict[str, str]:
 
     # The SYS subunit has the externally connectable inputs like HDMI1, AV1 etc...
     if ynca.SYS:
-        inputs = cast(System, ynca._subunits[Subunit.SYS]).inputs
+        inputs = cast(System, ynca._subunits[Subunit.SYS]).inp_names
 
     # Next to that there are internal inputs provided by subunits
     # for example the "Tuner"input is provided by the TUN subunit

--- a/ynca/modelinfo.py
+++ b/ynca/modelinfo.py
@@ -1,0 +1,81 @@
+"""This file contains info that is specific per model"""
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from .constants import SoundPrg
+
+
+@dataclass
+class ModelInfo:
+    soundprg: List[SoundPrg]
+
+
+BasicSoundPrgList: List[SoundPrg] = [
+    SoundPrg.HALL_IN_MUNICH,
+    SoundPrg.HALL_IN_VIENNA,
+    SoundPrg.CHAMBER,
+    SoundPrg.CELLAR_CLUB,
+    SoundPrg.THE_ROXY_THEATRE,
+    SoundPrg.THE_BOTTOM_LINE,
+    SoundPrg.SPORTS,
+    SoundPrg.ACTION_GAME,
+    SoundPrg.ROLEPLAYING_GAME,
+    SoundPrg.MUSIC_VIDEO,
+    SoundPrg.STANDARD,
+    SoundPrg.SPECTACLE,
+    SoundPrg.SCI_FI,
+    SoundPrg.ADVENTURE,
+    SoundPrg.DRAMA,
+    SoundPrg.MONO_MOVIE,
+    SoundPrg.TWO_CH_STEREO,
+    SoundPrg.SEVEN_CH_STEREO,
+    SoundPrg.SURROUND_DECODER,
+]
+
+ExtendedSoundPrgListSevenChannel: List[SoundPrg] = list(BasicSoundPrgList)
+ExtendedSoundPrgListSevenChannel.extend(
+    [
+        SoundPrg.HALL_IN_AMSTERDAM,
+        SoundPrg.CHURCH_IN_FREIBURG,
+        SoundPrg.CHURCH_IN_ROYAUMONT,
+        SoundPrg.VILLAGE_VANGUARD,
+        SoundPrg.WAREHOUSE_LOFT,
+        SoundPrg.RECITAL_OPERA,
+    ]
+)
+
+ExtendedSoundPrgListNineChannel: List[SoundPrg] = list(
+    ExtendedSoundPrgListSevenChannel
+)
+ExtendedSoundPrgListNineChannel.remove(SoundPrg.SEVEN_CH_STEREO)
+ExtendedSoundPrgListNineChannel.append(SoundPrg.NINE_CH_STEREO)
+
+
+MODELINFO = {
+    "HTR-7065": ModelInfo(soundprg=BasicSoundPrgList),
+    "RX-V671": ModelInfo(soundprg=BasicSoundPrgList),
+    "RX-V673": ModelInfo(soundprg=BasicSoundPrgList),
+    "RX-V773": ModelInfo(soundprg=BasicSoundPrgList),
+    "RX-A700": ModelInfo(soundprg=BasicSoundPrgList),
+    "RX-A710": ModelInfo(soundprg=BasicSoundPrgList),
+    "RX-A720": ModelInfo(soundprg=BasicSoundPrgList),
+    "RX-A800": ModelInfo(soundprg=BasicSoundPrgList),
+    "RX-A810": ModelInfo(soundprg=BasicSoundPrgList),
+    "RX-A820": ModelInfo(soundprg=BasicSoundPrgList),
+    "RX-A1000": ModelInfo(soundprg=BasicSoundPrgList),
+    "RX-A1010": ModelInfo(soundprg=BasicSoundPrgList),
+    "RX-A1020": ModelInfo(soundprg=BasicSoundPrgList),
+    "RX-A2000": ModelInfo(soundprg=ExtendedSoundPrgListSevenChannel),
+    "RX-A2010": ModelInfo(soundprg=ExtendedSoundPrgListNineChannel),
+    "RX-A2020": ModelInfo(soundprg=ExtendedSoundPrgListNineChannel),
+    "RX-A3000": ModelInfo(soundprg=ExtendedSoundPrgListSevenChannel),
+    "RX-A3010": ModelInfo(soundprg=ExtendedSoundPrgListNineChannel),
+    "RX-A3020": ModelInfo(soundprg=ExtendedSoundPrgListNineChannel),
+    "RX-V867": ModelInfo(soundprg=BasicSoundPrgList),
+    "RX-V871": ModelInfo(soundprg=BasicSoundPrgList),
+}
+
+
+def get_modelinfo(modelname: str) -> Optional[ModelInfo]:
+    return MODELINFO.get(modelname, None)

--- a/ynca/system.py
+++ b/ynca/system.py
@@ -22,7 +22,7 @@ class System(PowerFunctionMixin, SubunitBase):
 
     def _reset_internal_state(self):
         self._initialized = False
-        self._inputs: Dict[str, str] = {}
+        self._inp_names: Dict[str, str] = {}
 
         self._attr_modelname = None
         self._attr_version = None
@@ -50,7 +50,7 @@ class System(PowerFunctionMixin, SubunitBase):
             if input_id == "VAUX":
                 # Input ID used to set/get INP is actually V-AUX so compensate for that mismatch on the API
                 input_id = "V-AUX"
-            self._inputs[input_id] = value
+            self._inp_names[input_id] = value
         else:
             updated = False
 
@@ -67,6 +67,13 @@ class System(PowerFunctionMixin, SubunitBase):
         return self._attr_version
 
     @property
+    def inp_names(self) -> Dict[str, str]:
+        """Get input names"""
+        return dict(self._inp_names)
+
+    @property
     def inputs(self) -> Dict[str, str]:
-        """Get available external inputs"""
-        return dict(self._inputs)
+        logger.warning(
+            "The 'inputs' attribute is deprecated and replaced with 'inp_names' to better match naming of the YNCA spec"
+        )
+        return self.inp_names

--- a/ynca/zone.py
+++ b/ynca/zone.py
@@ -153,9 +153,17 @@ class ZoneBase(PowerFunctionMixin, PlaybackFunctionMixin, SubunitBase):
         self._put("STRAIGHT", "On" if value is True else "Off")
 
     @property
+    def scene_names(self) -> Dict[str, str]:
+        """Get a dictionary with scene names where key, value = id, name"""
+        return dict(self._scenes)
+
+    @property
     def scenes(self) -> Dict[str, str]:
         """Get the dictionary with scenes where key, value = id, name"""
-        return dict(self._scenes)
+        logger.warning(
+            "The 'scenes' attribute is deprecated and replaced with 'scene_names' to better match the naming in the YNCA spec"
+        )
+        return self.scene_names
 
     def activate_scene(self, scene_id: str):
         """Activate a scene"""

--- a/ynca/zone.py
+++ b/ynca/zone.py
@@ -63,7 +63,22 @@ class ZoneBase(PowerFunctionMixin, PlaybackFunctionMixin, SubunitBase):
     @property
     def name(self) -> str | None:
         """Get zone name"""
+        logger.warning(
+            "The 'name' attribute is deprecated and replaced with 'zonename' to better match the naming in the YNCA spec"
+        )
+        return self.zonename
+
+    @property
+    def zonename(self) -> str | None:
+        """Get zone name"""
         return self._attr_zonename
+
+    @zonename.setter
+    def zonename(self, zonename: str):
+        """Set zone name (0-9 characters)"""
+        if len(zonename) > 9:
+            raise ValueError("The provided name is too long, should be <= 9 characters")
+        self._put("ZONENAME", zonename)
 
     @property
     def mute(self) -> Mute | None:

--- a/ynca/zone.py
+++ b/ynca/zone.py
@@ -176,7 +176,7 @@ class ZoneBase(PowerFunctionMixin, PlaybackFunctionMixin, SubunitBase):
         logger.warning(
             "The 'scenes' attribute is deprecated and replaced with 'scene_names' to better match the naming in the YNCA spec"
         )
-        return self.scene_names
+        return self.scenenames
 
     def activate_scene(self, scene_id: str):
         """Activate a scene"""

--- a/ynca/zone.py
+++ b/ynca/zone.py
@@ -24,7 +24,7 @@ class ZoneBase(PowerFunctionMixin, PlaybackFunctionMixin, SubunitBase):
     def _reset_internal_state(self):
         self._max_volume = 16.5  # is 16.5 for zones where it is not configurable
         self._volume = None
-        self._scenes: Dict[str, str] = {}
+        self._scenenames: Dict[str, str] = {}
 
         self._attr_inp = None
         self._attr_mute = None
@@ -48,7 +48,7 @@ class ZoneBase(PowerFunctionMixin, PlaybackFunctionMixin, SubunitBase):
 
         if matches := re.match(r"SCENE(\d+)NAME", function_):
             scene_id = matches[1]
-            self._scenes[scene_id] = value
+            self._scenenames[scene_id] = value
         else:
             updated = False
 
@@ -166,9 +166,9 @@ class ZoneBase(PowerFunctionMixin, PlaybackFunctionMixin, SubunitBase):
         self._put("STRAIGHT", "On" if value is True else "Off")
 
     @property
-    def scene_names(self) -> Dict[str, str]:
+    def scenenames(self) -> Dict[str, str]:
         """Get a dictionary with scene names where key, value = id, name"""
-        return dict(self._scenes)
+        return dict(self._scenenames)
 
     @property
     def scenes(self) -> Dict[str, str]:
@@ -180,7 +180,7 @@ class ZoneBase(PowerFunctionMixin, PlaybackFunctionMixin, SubunitBase):
 
     def activate_scene(self, scene_id: str):
         """Activate a scene"""
-        if scene_id not in self._scenes.keys():
+        if scene_id not in self._scenenames.keys():
             raise ValueError("Invalid scene ID")
         else:
             self._put("SCENE", f"Scene {scene_id}")

--- a/ynca/zone.py
+++ b/ynca/zone.py
@@ -5,7 +5,7 @@ import logging
 from typing import Dict
 
 from .connection import YncaConnection, YncaProtocolStatus
-from .constants import SoundPrg, Mute, Subunit
+from .constants import Mute, Subunit
 from .function_mixins import PlaybackFunctionMixin, PowerFunctionMixin
 from .helpers import number_to_string_with_stepsize
 from .subunit import SubunitBase
@@ -131,14 +131,12 @@ class ZoneBase(PowerFunctionMixin, PlaybackFunctionMixin, SubunitBase):
         self._put("INP", value)
 
     @property
-    def soundprg(self) -> SoundPrg | None:
+    def soundprg(self) -> str | None:
         """Get the current DSP sound program"""
-        return (
-            SoundPrg(self._attr_soundprg) if self._attr_soundprg is not None else None
-        )
+        return self._attr_soundprg
 
     @soundprg.setter
-    def soundprg(self, value: SoundPrg):
+    def soundprg(self, value: str):
         """Set the DSP sound program"""
         self._put("SOUNDPRG", value)
 


### PR DESCRIPTION
Improve robustness of handling YNCA commands to allow to talk with more receivers like the TSR-700.

TSR-700 has the following behaviour that causes issues.
* Unknown SoundPrg which breaks the mapping --> Don't map, use plain strings
* No InpNames returned so we can't build a list of supported inputs --> No names, just report a list of all known inputs

Next to that added a modelinfo database to return supported SoundPrg per model.
Some more renames to better match YNCA protocol

Added reference logging for testing