### PR TITLE
Python 3.11 compatibility fix

### DIFF
--- a/ynca/constants.py
+++ b/ynca/constants.py
@@ -33,3 +33,6 @@ class Subunit(str, Enum):
     TUN = "TUN"
     UAW = "UAW"
     USB = "USB"
+
+    def __format__(self, spec) -> str:
+        return self.value


### PR DESCRIPTION
Python 3.11 changed the behaviour of format on Enums, see below. This PR makes the Subunit enum use the same format as on 3.10 and with that restores the enum-to-string "conversion" used on the library API (as it was intended by me). Might need to handle this better at some point, but this fixes the immediate issue.

I am not entirely sure why the tests do not detect it at all. The SubunitBase test should have used an actual enum for the DummySubunit used in the test, but changing that to an enum does not catch it. Needs improvment. For now just manual test.

See https://docs.python.org/3/whatsnew/3.11.html#enum
>Changed [Enum.__format__()](https://docs.python.org/3/library/enum.html#enum.Enum.__format__) (the default for [format()](https://docs.python.org/3/library/functions.html#format), [str.format()](https://docs.python.org/3/library/stdtypes.html#str.format) and [f-string](https://docs.python.org/3/glossary.html#term-f-string)s) to always produce the same result as Enum.__str__(): for enums inheriting from [ReprEnum](https://docs.python.org/3/library/enum.html#enum.ReprEnum) it will be the member’s value; for all other enums it will be the enum and member name (e.g. Color.RED).
