### PR TITLE
Add a 40s idle timeout as per the YNCA spec

### DIFF
--- a/ynca/server.py
+++ b/ynca/server.py
@@ -316,7 +316,7 @@ class YncaCommandHandler(socketserver.StreamRequestHandler):
                     self.request.shutdown(socket.SHUT_RDWR)
                     self.request.close()
                     return
-                time.sleep(1)
+                time.sleep(0.1)
             else:  # got line
                 if bytes_line == b"":
                     print("--- Client disconnected")


### PR DESCRIPTION
This change makes the YNCA simulator disconnect after 40 seconds of no commands as per the YNCA spec document. I'm a complete novice with threading so this might not be the best way to do it but it seems to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Enhanced server capabilities to manage multiple client connections more efficiently, including automatic disconnection after a period of inactivity.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->