### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,6 +3,10 @@
 
 name: Upload Python Package
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   release:
     types: [prereleased, released]


### PR DESCRIPTION
Potential fix for [https://github.com/mvdwetering/ynca/security/code-scanning/2](https://github.com/mvdwetering/ynca/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow to explicitly define the minimal permissions required. Since the workflow involves checking out the repository and publishing a package, it needs `contents: read` to access the repository and `packages: write` to upload the package. These permissions will be explicitly set to ensure the workflow operates securely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflow to explicitly set permissions for repository contents and package uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->