### PR TITLE
Add ELEVEN_CH_STEREO option to SoundPrg enum

### DIFF
--- a/src/ynca/enums.py
+++ b/src/ynca/enums.py
@@ -432,6 +432,7 @@ class SoundPrg(StrEnum):
     FIVE_CH_STEREO = "5ch Stereo"
     SEVEN_CH_STEREO = "7ch Stereo"
     NINE_CH_STEREO = "9ch Stereo"
+    ELEVEN_CH_STEREO = "11ch Stereo"
     SURROUND_DECODER = "Surround Decoder"
     ALL_CH_STEREO = "All-Ch Stereo"
     ENHANCED = "Enhanced"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the "11ch Stereo" sound program option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->